### PR TITLE
Update ApplePay.m

### DIFF
--- a/ios/ApplePay.m
+++ b/ios/ApplePay.m
@@ -11,4 +11,9 @@ RCT_EXTERN_METHOD(initApplePay:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(canMakePayments:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 @end


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `react-native-apple-payment@1.1.1` for the project I'm working on.

to suppress ` WARN  Module ApplePay requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.` warning we need to add `requiresMainQueueSetup`

From React native docs [https://reactnative.dev/docs/0.63/native-modules-ios]

Here is the diff that solved my problem:

```diff
diff --git a/node_modules/react-native-apple-payment/ios/ApplePay.m b/node_modules/react-native-apple-payment/ios/ApplePay.m
index d9412ea..daf33db 100644
--- a/node_modules/react-native-apple-payment/ios/ApplePay.m
+++ b/node_modules/react-native-apple-payment/ios/ApplePay.m
@@ -10,5 +10,8 @@ @interface RCT_EXTERN_MODULE(ApplePay, NSObject)
 
 RCT_EXTERN_METHOD(canMakePayments:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
-
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
 @end
```